### PR TITLE
fix bug when call format() with only mandatory argument (amount)

### DIFF
--- a/Model/Plugin/PriceCurrency.php
+++ b/Model/Plugin/PriceCurrency.php
@@ -21,6 +21,11 @@ class PriceCurrency extends PriceFormatPluginAbstract
     ) {
 
         if ($this->getConfig()->isEnable()) {
+
+            if(!isset($args[1])){
+                $args[1] = true;
+            }
+
             $args[2] = $this->getPricePrecision(); // Precision argument
         }
 


### PR DESCRIPTION
at layered navigation magento calls priceCurrency->format() with only amount argument

> $formattedFromPrice = $this->priceCurrency->format($fromPrice);

at this state func_get_args get $args as an array with only one element so the plugin cannot set $args[2],

I've fixed the bug with setting includeContainer to default value when no explicit set.