### PR TITLE
Calin/price fixes

### DIFF
--- a/Model/Plugin/OrderPlugin.php
+++ b/Model/Plugin/OrderPlugin.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ *
+ * @package Lillik\PriceDecimal\Model\Plugin
+ *
+ * @author  Lilian Codreanu <lilian.codreanu@gmail.com>
+ */
+
+namespace Lillik\PriceDecimal\Model\Plugin;
+
+class OrderPlugin extends PriceFormatPluginAbstract
+{
+    /**
+     * @param \Magento\Sales\Model\Order $subject
+     * @param array ...$args
+     * @return array
+     */
+    public function beforeFormatPricePrecision(
+        \Magento\Sales\Model\Order $subject,
+        ...$args
+    )
+    {
+        //is enabled
+        if ($this->getConfig()->isEnable()) {
+            //change the precision
+            $args[1] = $this->getPricePrecision();
+        }
+
+        return $args;
+    }
+
+}

--- a/Model/Plugin/PriceCurrency.php
+++ b/Model/Plugin/PriceCurrency.php
@@ -14,21 +14,82 @@ class PriceCurrency extends PriceFormatPluginAbstract
     /**
      * {@inheritdoc}
      */
-    public function aroundFormat(
+    public function beforeFormat(
         \Magento\Directory\Model\PriceCurrency $subject,
-        callable $proceed,
         ...$args
     ) {
 
         if ($this->getConfig()->isEnable()) {
-
-            if(!isset($args[1])){
+            // add the optional arg
+            if(! isset($args[1])){
                 $args[1] = true;
             }
-
-            $args[2] = $this->getPricePrecision(); // Precision argument
+            // Precision argument
+            $args[2] = $this->getPricePrecision();
         }
 
-        return $proceed(...$args);
+        return $args;
+    }
+
+    /**
+     * @param \Magento\Directory\Model\PriceCurrency $subject
+     * @param callable $proceed
+     * @param $price
+     * @param array ...$args
+     * @return float
+     */
+    public function aroundRound(
+        \Magento\Directory\Model\PriceCurrency $subject,
+        callable $proceed,
+        $price,
+        ...$args
+    )
+    {
+        if ($this->getConfig()->isEnable()) {
+            return round($price, $this->getPricePrecision());
+
+        } else {
+            return $proceed($price);
+        }
+    }
+
+    /**
+     * @param \Magento\Directory\Model\PriceCurrency $subject
+     * @param array ...$args
+     * @return array
+     */
+    public function beforeConvertAndFormat(
+        \Magento\Directory\Model\PriceCurrency $subject,
+        ...$args
+    )
+    {
+        if ($this->getConfig()->isEnable()) {
+            // add the optional args
+            $args[1] = isset($args[1])? $args[1] : null;
+            $args[2] = isset($args[2])? $args[2] : null;
+            $args[3] = $this->getPricePrecision();
+        }
+
+        return $args;
+    }
+
+    /**
+     * @param \Magento\Directory\Model\PriceCurrency $subject
+     * @param array ...$args
+     * @return array
+     */
+    public function beforeConvertAndRound(
+        \Magento\Directory\Model\PriceCurrency $subject,
+        ...$args
+    )
+    {
+        if ($this->getConfig()->isEnable()) {
+            //add optional args
+            $args[1] = isset($args[1])? $args[1] : null;
+            $args[2] = isset($args[2])? $args[2] : null;
+            $args[3] = $this->getPricePrecision();
+        }
+
+        return $args;
     }
 }

--- a/Test/Unit/Plugin/Model/PriceCurrencyTest.php
+++ b/Test/Unit/Plugin/Model/PriceCurrencyTest.php
@@ -12,7 +12,7 @@ use Lillik\PriceDecimal\Model\ConfigInterface;
 use Lillik\PriceDecimal\Model\Plugin\PriceCurrency;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 
-class PriceCurrencyTest extends \PHPUnit_Framework_TestCase
+class PriceCurrencyTest extends \PHPUnit\Framework\TestCase
 {
 
     private $closureMock;

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -2,21 +2,16 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
 
     <preference for="Lillik\PriceDecimal\Model\ConfigInterface" type="Lillik\PriceDecimal\Model\Config" />
-    <!--<preference for="Magento\Framework\Locale\CurrencyInterface" type="Magento\Framework\Locale\Currency" />-->
     <preference for="Magento\Framework\CurrencyInterface" type="Lillik\PriceDecimal\Model\Currency" />
 
     <type name="Magento\Framework\Pricing\PriceCurrencyInterface">
-        <plugin name="lillik_price_decimal_price_currency"
-                type="Lillik\PriceDecimal\Model\Plugin\PriceCurrency"
-                sortOrder="10"
-                disabled="false"/>
+        <plugin name="lillik_price_decimal_price_currency" type="Lillik\PriceDecimal\Model\Plugin\PriceCurrency" sortOrder="10" disabled="false"/>
     </type>
-
     <type name="Magento\Framework\Locale\FormatInterface">
-        <plugin name="lillik_price_decimal_local_format"
-                type="Lillik\PriceDecimal\Model\Plugin\Local\Format"
-                sortOrder="10"
-                disabled="false"/>
+        <plugin name="lillik_price_decimal_local_format" type="Lillik\PriceDecimal\Model\Plugin\Local\Format" sortOrder="10" disabled="false"/>
+    </type>
+    <type name="Magento\Sales\Api\Data\OrderInterface">
+        <plugin name="lillik_price_decimal_for_orders" type="Lillik\PriceDecimal\Model\Plugin\OrderPlugin" sortOrder="10" disabled="false"/>
     </type>
 
 </config>

--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -1,0 +1,7 @@
+var config = {
+    map: {
+        '*': {
+            'Magento_Catalog/js/price-utils' : 'Lillik_PriceDecimal/js/price-utils'
+        }
+    }
+};

--- a/view/frontend/web/js/price-utils.js
+++ b/view/frontend/web/js/price-utils.js
@@ -1,0 +1,127 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+/**
+ * @api
+ */
+define([
+    'jquery',
+    'underscore'
+], function ($, _) {
+    'use strict';
+
+    var globalPriceFormat = {
+        requiredPrecision: 2,
+        integerRequired: 1,
+        decimalSymbol: ',',
+        groupSymbol: ',',
+        groupLength: ','
+    };
+
+    /**
+     * Repeats {string} {times} times
+     * @param  {String} string
+     * @param  {Number} times
+     * @return {String}
+     */
+    function stringPad(string, times) {
+        return (new Array(times + 1)).join(string);
+    }
+
+    /**
+     * Formatter for price amount
+     * @param  {Number}  amount
+     * @param  {Object}  format
+     * @param  {Boolean} isShowSign
+     * @return {String}              Formatted value
+     */
+    function formatPrice(amount, format, isShowSign) {
+        var s = '',
+            precision, integerRequired, decimalSymbol, groupSymbol, groupLength, pattern, i, pad, j, re, r, am;
+
+        format = _.extend(globalPriceFormat, format);
+
+        // copied from price-option.js | Could be refactored with varien/js.js
+
+        precision = isNaN(format.requiredPrecision = Math.abs(format.requiredPrecision)) ? 2 : format.requiredPrecision;
+        integerRequired = isNaN(format.integerRequired = Math.abs(format.integerRequired)) ? 1 : format.integerRequired;
+        decimalSymbol = format.decimalSymbol === undefined ? ',' : format.decimalSymbol;
+        groupSymbol = format.groupSymbol === undefined ? '.' : format.groupSymbol;
+        groupLength = format.groupLength === undefined ? 3 : format.groupLength;
+        pattern = format.pattern || '%s';
+
+        if (isShowSign === undefined || isShowSign === true) {
+            s = amount < 0 ? '-' : isShowSign ? '+' : '';
+        } else if (isShowSign === false) {
+            s = '';
+        }
+        pattern = pattern.indexOf('{sign}') < 0 ? s + pattern : pattern.replace('{sign}', s);
+
+        // we're avoiding the usage of to fixed, and using round instead with the e representation to address
+        // numbers like 1.005 = 1.01. Using ToFixed to only provide trailig zeroes in case we have a whole number
+        i = parseInt(
+            amount = Number(Math.round(Math.abs(+amount || 0) + 'e+' + precision) + ('e-' + precision)),
+            10
+        ) + '';
+        pad = i.length < integerRequired ? integerRequired - i.length : 0;
+
+        i = stringPad('0', pad) + i;
+
+        j = i.length > groupLength ? i.length % groupLength : 0;
+        re = new RegExp('(\\d{' + groupLength + '})(?=\\d)', 'g');
+
+        // replace(/-/, 0) is only for fixing Safari bug which appears
+        // when Math.abs(0).toFixed() executed on '0' number.
+        // Result is '0.-0' :(
+
+        am = Number(Math.round(Math.abs(amount - i) + 'e+' + precision) + ('e-' + precision));
+        r = (j ? i.substr(0, j) + groupSymbol : '') +
+            i.substr(j).replace(re, '$1' + groupSymbol) +
+            (precision ? decimalSymbol + am.toFixed(precision).replace(/-/, 0).slice(2) : '');
+
+        return pattern.replace('%s', r).replace(/^\s\s*/, '').replace(/\s\s*$/, '');
+    }
+
+    /**
+     * Deep clone of Object. Doesn't support functions
+     * @param {Object} obj
+     * @return {Object}
+     */
+    function objectDeepClone(obj) {
+        return JSON.parse(JSON.stringify(obj));
+    }
+
+    /**
+     * Helper to find ID in name attribute
+     * @param   {jQuery} element
+     * @returns {undefined|String}
+     */
+    function findOptionId(element) {
+        var re, id, name;
+
+        if (!element) {
+            return id;
+        }
+        name = $(element).attr('name');
+
+        if (name.indexOf('[') !== -1) {
+            re = /\[([^\]]+)?\]/;
+        } else {
+            re = /_([^\]]+)?_/; // just to support file-type-option
+        }
+        id = re.exec(name) && re.exec(name)[1];
+
+        if (id) {
+            return id;
+        }
+    }
+
+    return {
+        formatPrice: formatPrice,
+        deepClone: objectDeepClone,
+        strPad: stringPad,
+        findOptionId: findOptionId
+    };
+});


### PR DESCRIPTION
This PR should fix some price fixing for display price

* When placing an order account information will display the incorrect value for the product price and totals so the display price will be (default 2 digits) also  the round will be used based on that.
* On product page the price will be rounded by 2 digits, there should be an magento bug https://github.com/magento/magento2/issues/14249
* Category page is displaying the price with correct digits but the number will be rounded up using the 2 digits


@lillik 😉 