### PR TITLE
Fix composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,6 @@
     ],
     "license": "Apache-2.0",
     "type": "magento2-module",
-    "version": "1.0.6",
     "authors": [
         {
             "name": "LillikPro",
@@ -18,7 +17,7 @@
         "source": ""
     },
     "require": {
-        "php": "~5.6.0|7.0.2|7.0.4|~7.0.6|~7.1|~7.3|~7.4",
+        "php": "~5.6.0|~7.0.6|~7.1",
         "magento/framework": "*"
     },
     "autoload": {


### PR DESCRIPTION
The current `composer.json` for the `1.0.8` tag erroneously contains `"version": "1.0.6"`, which causes Composer to only install version `1.0.7` instead, even though a newer version is available. The `version` key should be omitted from the `composer.json` for packages that are version controlled and distributed via either a public or private packagist (see [here](https://getcomposer.org/doc/04-schema.md#version)).

I also streamlined the PHP requirements. `~7.0.6` already excludes `7.0.2` and `7.0.4` and `~7.1` already includes any `7.*` version equal or higher than `7.1.0`.